### PR TITLE
Feat/21 찜한 콘센트 리스트 조회 api

### DIFF
--- a/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
@@ -47,11 +47,11 @@ public class BookmarkController {
    }
 
   @GetMapping("/bookmark")
-  public ApiResponse<BookmarkResponseDto.BookmarkListDto> bookmarkList(@RequestParam(name = "page") Integer page, Authentication authentication) {
+  public ApiResponse<BookmarkResponseDto.BookmarkList> bookmarkList(@RequestParam(name = "page") Integer page, Authentication authentication) {
 
     Long memberId = Long.parseLong(authentication.getName());
     Page<Bookmark> bookmarkList = bookmarkService.findBookmarkList(memberId, page);
-    return ApiResponse.onSuccess(BookmarkConverter.bookmarkListDto(bookmarkList));
+    return ApiResponse.onSuccess(BookmarkConverter.toBookmarkListResponse(bookmarkList));
   }
 
 

--- a/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
@@ -10,9 +10,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 

--- a/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
@@ -3,8 +3,11 @@ package com.vincent.domain.bookmark.controller;
 import com.vincent.apipayload.ApiResponse;
 import com.vincent.domain.bookmark.controller.dto.BookmarkResponseDto;
 import com.vincent.domain.bookmark.converter.BookmarkConverter;
+import com.vincent.domain.bookmark.entity.Bookmark;
 import com.vincent.domain.bookmark.service.BookmarkService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +28,14 @@ public class BookmarkController {
     Long memberId = Long.parseLong(authentication.getName());
     BookmarkService.BookmarkResult result = bookmarkService.Bookmark(socketId, memberId);
     return ApiResponse.onSuccess(BookmarkConverter.toBookmarkResponse(result.getBookmarkId()));
+  }
+
+  @GetMapping("/bookmark")
+  public ApiResponse<BookmarkResponseDto.BookmarkListDto> bookmarkList(@RequestParam(name = "page") Integer page, Authentication authentication) {
+
+    Long memberId = Long.parseLong(authentication.getName());
+    Page<Bookmark> bookmarkList = bookmarkService.findBookmarkList(memberId, page);
+    return ApiResponse.onSuccess(BookmarkConverter.bookmarkListDto(bookmarkList));
   }
 
 

--- a/src/main/java/com/vincent/domain/bookmark/controller/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/vincent/domain/bookmark/controller/dto/BookmarkResponseDto.java
@@ -21,9 +21,9 @@ public class BookmarkResponseDto {
   @Getter
   @NoArgsConstructor
   @AllArgsConstructor
-  public static class BookmarkListDto {
+  public static class BookmarkList {
 
-    List<BookmarkDto> bookmarks;
+    List<BookmarkDetail> bookmarkDetails;
     Integer listSize;
     Integer totalPage;
     Long totalElements;
@@ -36,7 +36,7 @@ public class BookmarkResponseDto {
   @Getter
   @NoArgsConstructor
   @AllArgsConstructor
-  public static class BookmarkDto {
+  public static class BookmarkDetail {
 
     Long bookmarkId;
     Long socketId;

--- a/src/main/java/com/vincent/domain/bookmark/controller/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/vincent/domain/bookmark/controller/dto/BookmarkResponseDto.java
@@ -1,5 +1,6 @@
 package com.vincent.domain.bookmark.controller.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,5 +17,34 @@ public class BookmarkResponseDto {
   public static class Bookmark {
 
     Long bookmarkId;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class BookmarkListDto {
+
+    List<BookmarkDto> bookmarks;
+    Integer listSize;
+    Integer totalPage;
+    Long totalElements;
+    Boolean isFirst;
+    Boolean isLast;
+
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class BookmarkDto {
+
+    Long bookmarkId;
+    Long socketId;
+    String socketName;
+    String socketImage;
+    String buildingName;
+
   }
 }

--- a/src/main/java/com/vincent/domain/bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/com/vincent/domain/bookmark/converter/BookmarkConverter.java
@@ -14,8 +14,8 @@ public class BookmarkConverter {
         .build();
   }
 
-  public static BookmarkResponseDto.BookmarkDto bookmarkDto(Bookmark bookmark){
-    return BookmarkResponseDto.BookmarkDto.builder()
+  public static BookmarkResponseDto.BookmarkDetail toBookmarkDetailResponse(Bookmark bookmark){
+    return BookmarkResponseDto.BookmarkDetail.builder()
         .bookmarkId(bookmark.getId())
         .socketId(bookmark.getSocket().getId())
         .socketName(bookmark.getSocket().getName())
@@ -23,18 +23,18 @@ public class BookmarkConverter {
         .buildingName(bookmark.getSocket().getBuilding().getName())
         .build();
   }
-  public static BookmarkResponseDto.BookmarkListDto bookmarkListDto(Page<Bookmark> bookmarkList){
+  public static BookmarkResponseDto.BookmarkList toBookmarkListResponse(Page<Bookmark> bookmarkList){
 
-    List<BookmarkResponseDto.BookmarkDto> bookmarkDtoList = bookmarkList.stream()
-        .map(BookmarkConverter::bookmarkDto).collect(Collectors.toList());
+    List<BookmarkResponseDto.BookmarkDetail> bookmarkDetailList = bookmarkList.stream()
+        .map(BookmarkConverter::toBookmarkDetailResponse).collect(Collectors.toList());
 
-    return BookmarkResponseDto.BookmarkListDto.builder()
+    return BookmarkResponseDto.BookmarkList.builder()
         .isLast(bookmarkList.isLast())
         .isFirst(bookmarkList.isFirst())
         .totalPage(bookmarkList.getTotalPages())
         .totalElements(bookmarkList.getTotalElements())
-        .listSize(bookmarkDtoList.size())
-        .bookmarks(bookmarkDtoList)
+        .listSize(bookmarkDetailList.size())
+        .bookmarkDetails(bookmarkDetailList)
         .build();
   }
 }

--- a/src/main/java/com/vincent/domain/bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/com/vincent/domain/bookmark/converter/BookmarkConverter.java
@@ -1,15 +1,40 @@
 package com.vincent.domain.bookmark.converter;
 
 import com.vincent.domain.bookmark.controller.dto.BookmarkResponseDto;
-import com.vincent.domain.member.controller.dto.MemberResponseDto;
-
-import java.time.LocalDateTime;
+import com.vincent.domain.bookmark.entity.Bookmark;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 
 public class BookmarkConverter {
 
   public static BookmarkResponseDto.Bookmark toBookmarkResponse(Long bookmarkId) {
     return BookmarkResponseDto.Bookmark.builder()
         .bookmarkId(bookmarkId)
+        .build();
+  }
+
+  public static BookmarkResponseDto.BookmarkDto bookmarkDto(Bookmark bookmark){
+    return BookmarkResponseDto.BookmarkDto.builder()
+        .bookmarkId(bookmark.getId())
+        .socketId(bookmark.getSocket().getId())
+        .socketName(bookmark.getSocket().getName())
+        .socketImage(bookmark.getSocket().getImage())
+        .buildingName(bookmark.getSocket().getBuilding().getName())
+        .build();
+  }
+  public static BookmarkResponseDto.BookmarkListDto bookmarkListDto(Page<Bookmark> bookmarkList){
+
+    List<BookmarkResponseDto.BookmarkDto> bookmarkDtoList = bookmarkList.stream()
+        .map(BookmarkConverter::bookmarkDto).collect(Collectors.toList());
+
+    return BookmarkResponseDto.BookmarkListDto.builder()
+        .isLast(bookmarkList.isLast())
+        .isFirst(bookmarkList.isFirst())
+        .totalPage(bookmarkList.getTotalPages())
+        .totalElements(bookmarkList.getTotalElements())
+        .listSize(bookmarkDtoList.size())
+        .bookmarks(bookmarkDtoList)
         .build();
   }
 }

--- a/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
@@ -15,6 +15,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Boolean existsBySocketAndMember(Socket socket, Member member);
 
-  Page<Bookmark> findAllByMember(Member member, PageRequest pageRequest);
+    Page<Bookmark> findAllByMember(Member member, PageRequest pageRequest);
 
 }

--- a/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
@@ -3,6 +3,9 @@ package com.vincent.domain.bookmark.repository;
 import com.vincent.domain.bookmark.entity.Bookmark;
 import com.vincent.domain.member.entity.Member;
 import com.vincent.domain.socket.entity.Socket;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,5 +16,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
 
   Boolean existsBySocketAndMember(Socket socket, Member member);
+
+  Page<Bookmark> findAllByMember(Member member, PageRequest pageRequest);
 
 }

--- a/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
@@ -57,7 +57,6 @@ public class BookmarkService {
 
   }
 
-  @Transactional
   public Page<Bookmark> findBookmarkList(Long memberId, Integer page) {
 
     Member member = findMemberById(memberId);

--- a/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
@@ -8,9 +8,13 @@ import com.vincent.domain.member.repository.MemberRepository;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.domain.socket.repository.SocketRepository;
 import com.vincent.exception.handler.ErrorHandler;
+import java.awt.print.Book;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +44,15 @@ public class BookmarkService {
     return new BookmarkResult(bookmark.getId());
   }
 
+  @Transactional
+  public Page<Bookmark> findBookmarkList(Long memberId, Integer page) {
+
+    Member member = findMemberById(memberId);
+
+    return bookmarkRepository.findAllByMember(member, PageRequest.of(page, 10));
+
+  }
+
   @Getter
   @AllArgsConstructor
   public static class BookmarkResult {
@@ -56,6 +69,7 @@ public class BookmarkService {
         .socket(socket)
         .build());
   }
+
 
 
 

--- a/src/main/java/com/vincent/domain/socket/entity/Socket.java
+++ b/src/main/java/com/vincent/domain/socket/entity/Socket.java
@@ -41,5 +41,9 @@ public class Socket {
   @Column(columnDefinition = "TEXT")
   private String image;
 
+  @Column(nullable = false, length = 20)
+  private String name;
+
+
 
 }

--- a/src/test/java/com/vincent/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/BookmarkControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -46,8 +47,8 @@ public class BookmarkControllerTest {
     @MockBean
     private BookmarkService bookmarkService;
 
-    @MockBean
-    private BookmarkConverter bookmarkConverter;
+    //@MockBean
+    //private BookmarkConverter bookmarkConverter;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -227,22 +228,31 @@ public class BookmarkControllerTest {
         int page = 0;
 
         Bookmark bookmark = Mockito.mock(Bookmark.class);
+
+        Socket socket = Mockito.mock(Socket.class);
+        when(socket.getId()).thenReturn(1L);
+        when(socket.getName()).thenReturn("socketName");
+        when(socket.getImage()).thenReturn("socketImage");
+
+        Building building = Mockito.mock(Building.class);
+        when(building.getName()).thenReturn("buildingName");
+
         when(bookmark.getId()).thenReturn(1L);
-        when(bookmark.getSocket()).thenReturn(Mockito.mock(Socket.class));
-        when(bookmark.getSocket().getId()).thenReturn(1L);
-        when(bookmark.getSocket().getName()).thenReturn("socketName");
-        when(bookmark.getSocket().getImage()).thenReturn("socketImage");
-        when(bookmark.getSocket().getBuilding()).thenReturn(Mockito.mock(Building.class));
-        when(bookmark.getSocket().getBuilding().getName()).thenReturn("buildingName");
+        when(bookmark.getSocket()).thenReturn(socket);
+        when(socket.getBuilding()).thenReturn(building);
 
         Page<Bookmark> bookmarkPage = new PageImpl<>(Collections.singletonList(bookmark), PageRequest.of(page, 10), 1);
+
+        BookmarkResponseDto.BookmarkDetail bookmarkDetail = new BookmarkResponseDto.BookmarkDetail(
+            1L, 1L, "socketName", "socketImage", "buildingName"
+        );
         BookmarkResponseDto.BookmarkList bookmarkListDto = new BookmarkResponseDto.BookmarkList(
-            Collections.singletonList(new BookmarkResponseDto.BookmarkDetail(1L, 1L, "socketName", "socketImage", "buildingName")),
+            Collections.singletonList(bookmarkDetail),
             1, 1, 1L, true, true
         );
 
         when(bookmarkService.findBookmarkList(eq(memberId), eq(page))).thenReturn(bookmarkPage);
-        when(BookmarkConverter.toBookmarkListResponse(eq(bookmarkPage))).thenReturn(bookmarkListDto);
+        when(BookmarkConverter.toBookmarkListResponse(any(Page.class))).thenReturn(bookmarkListDto);
 
         ResultActions resultActions = mockMvc.perform(get("/v1/bookmark")
             .param("page", String.valueOf(page))

--- a/src/test/java/com/vincent/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/BookmarkControllerTest.java
@@ -2,12 +2,22 @@ package com.vincent.domain.bookmark.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.bookmark.controller.dto.BookmarkResponseDto;
+import com.vincent.domain.bookmark.converter.BookmarkConverter;
+import com.vincent.domain.bookmark.entity.Bookmark;
 import com.vincent.domain.bookmark.service.BookmarkService;
+import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.socket.entity.Socket;
 import com.vincent.exception.handler.ErrorHandler;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -16,7 +26,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,15 +43,19 @@ public class BookmarkControllerTest {
     @MockBean
     private BookmarkService bookmarkService;
 
+    @MockBean
+    private BookmarkConverter bookmarkConverter;
+
     @Autowired
     private ObjectMapper objectMapper;
+
+    // 테스트 데이터 준비
+    Long socketId = 1L;
+    Long memberId = 1L; // 인증된 사용자 ID
 
     @Test
     @WithMockUser(username = "1")
     public void 북마크성공() throws Exception {
-        // 테스트 데이터 준비
-        Long socketId = 1L;
-        Long memberId = 1L; // 인증된 사용자 ID
         BookmarkService.BookmarkResult result = new BookmarkService.BookmarkResult(socketId);
 
         // Mocking 서비스 응답
@@ -63,9 +79,6 @@ public class BookmarkControllerTest {
     @Test
     @WithMockUser(username = "1")
     public void 북마크실패_이미북마크존재() throws Exception {
-        // 테스트 데이터 준비
-        Long socketId = 1L;
-        Long memberId = 1L; // 인증된 사용자 ID
 
         // Mocking 서비스 응답
         when(bookmarkService.bookmark(eq(socketId), eq(memberId)))
@@ -86,9 +99,6 @@ public class BookmarkControllerTest {
     @Test
     @WithMockUser(username = "1")
     public void 북마크실패_멤버없음() throws Exception {
-        // 테스트 데이터 준비
-        Long socketId = 1L;
-        Long memberId = 1L; // 인증된 사용자 ID
 
         // Mocking 서비스 응답
         when(bookmarkService.bookmark(eq(socketId), eq(memberId)))
@@ -109,9 +119,6 @@ public class BookmarkControllerTest {
     @Test
     @WithMockUser(username = "1")
     public void 북마크실패_소켓없음() throws Exception {
-        // 테스트 데이터 준비
-        Long socketId = 1L;
-        Long memberId = 1L; // 인증된 사용자 ID
 
         // Mocking 서비스 응답
         when(bookmarkService.bookmark(eq(socketId), eq(memberId)))
@@ -127,5 +134,66 @@ public class BookmarkControllerTest {
             .andExpect(jsonPath("$.isSuccess").value(false))
             .andExpect(jsonPath("$.code").value(ErrorStatus.SOCKET_NOT_FOUND.getReason().getCode()))
             .andExpect(jsonPath("$.message").value(ErrorStatus.SOCKET_NOT_FOUND.getReason().getMessage()));
+    }
+
+
+
+    @Test
+    @WithMockUser(username = "1")
+    public void 북마크리스트조회성공() throws Exception {
+
+        int page = 0;
+
+        Bookmark bookmark = Mockito.mock(Bookmark.class);
+        when(bookmark.getId()).thenReturn(1L);
+        when(bookmark.getSocket()).thenReturn(Mockito.mock(Socket.class));
+        when(bookmark.getSocket().getId()).thenReturn(1L);
+        when(bookmark.getSocket().getName()).thenReturn("socketName");
+        when(bookmark.getSocket().getImage()).thenReturn("socketImage");
+        when(bookmark.getSocket().getBuilding()).thenReturn(Mockito.mock(Building.class));
+        when(bookmark.getSocket().getBuilding().getName()).thenReturn("buildingName");
+
+        Page<Bookmark> bookmarkPage = new PageImpl<>(Collections.singletonList(bookmark), PageRequest.of(page, 10), 1);
+        BookmarkResponseDto.BookmarkListDto bookmarkListDto = new BookmarkResponseDto.BookmarkListDto(
+            Collections.singletonList(new BookmarkResponseDto.BookmarkDto(1L, 1L, "socketName", "socketImage", "buildingName")),
+            1, 1, 1L, true, true
+        );
+
+        when(bookmarkService.findBookmarkList(eq(memberId), eq(page))).thenReturn(bookmarkPage);
+        when(BookmarkConverter.bookmarkListDto(eq(bookmarkPage))).thenReturn(bookmarkListDto);
+
+        ResultActions resultActions = mockMvc.perform(get("/v1/bookmark")
+            .param("page", String.valueOf(page))
+            .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.isSuccess").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"))
+            .andExpect(jsonPath("$.message").value("성공입니다"))
+            .andExpect(jsonPath("$.result.bookmarks").isArray())
+            .andExpect(jsonPath("$.result.bookmarks[0].bookmarkId").value(1L))
+            .andExpect(jsonPath("$.result.bookmarks[0].socketId").value(1L))
+            .andExpect(jsonPath("$.result.bookmarks[0].socketName").value("socketName"))
+            .andExpect(jsonPath("$.result.bookmarks[0].socketImage").value("socketImage"))
+            .andExpect(jsonPath("$.result.bookmarks[0].buildingName").value("buildingName"));
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    public void 북마크리스트조회실패_멤버없음() throws Exception {
+
+        int page = 0;
+
+        when(bookmarkService.findBookmarkList(eq(memberId), eq(page)))
+            .thenThrow(new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        ResultActions resultActions = mockMvc.perform(get("/v1/bookmark")
+            .param("page", String.valueOf(page))
+            .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+        resultActions.andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.isSuccess").value(false))
+            .andExpect(jsonPath("$.code").value(ErrorStatus.MEMBER_NOT_FOUND.getReason().getCode()))
+            .andExpect(jsonPath("$.message").value(ErrorStatus.MEMBER_NOT_FOUND.getReason().getMessage()));
     }
 }

--- a/src/test/java/com/vincent/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/BookmarkControllerTest.java
@@ -236,13 +236,13 @@ public class BookmarkControllerTest {
         when(bookmark.getSocket().getBuilding().getName()).thenReturn("buildingName");
 
         Page<Bookmark> bookmarkPage = new PageImpl<>(Collections.singletonList(bookmark), PageRequest.of(page, 10), 1);
-        BookmarkResponseDto.BookmarkListDto bookmarkListDto = new BookmarkResponseDto.BookmarkListDto(
-            Collections.singletonList(new BookmarkResponseDto.BookmarkDto(1L, 1L, "socketName", "socketImage", "buildingName")),
+        BookmarkResponseDto.BookmarkList bookmarkListDto = new BookmarkResponseDto.BookmarkList(
+            Collections.singletonList(new BookmarkResponseDto.BookmarkDetail(1L, 1L, "socketName", "socketImage", "buildingName")),
             1, 1, 1L, true, true
         );
 
         when(bookmarkService.findBookmarkList(eq(memberId), eq(page))).thenReturn(bookmarkPage);
-        when(BookmarkConverter.bookmarkListDto(eq(bookmarkPage))).thenReturn(bookmarkListDto);
+        when(BookmarkConverter.toBookmarkListResponse(eq(bookmarkPage))).thenReturn(bookmarkListDto);
 
         ResultActions resultActions = mockMvc.perform(get("/v1/bookmark")
             .param("page", String.valueOf(page))

--- a/src/test/java/com/vincent/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/BookmarkServiceTest.java
@@ -9,11 +9,16 @@ import com.vincent.domain.socket.entity.Socket;
 
 import com.vincent.domain.socket.repository.SocketRepository;
 import com.vincent.exception.handler.ErrorHandler;
+import java.util.Collections;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -48,10 +53,14 @@ public class BookmarkServiceTest {
         MockitoAnnotations.openMocks(this);
     }
 
+
+    Long socketId = 1L;
+    Long memberId = 1L;
+    Integer page = 0;
+
     @Test
     public void 북마크성공() {
-        Long socketId = 1L;
-        Long memberId = 1L;
+
 
         when(memberRepository.findById(memberId)).thenReturn(java.util.Optional.of(member));
         when(socketRepository.findById(socketId)).thenReturn(java.util.Optional.of(socket));
@@ -68,8 +77,7 @@ public class BookmarkServiceTest {
 
     @Test
     public void 북마크실패_이미북마크존재() {
-        Long socketId = 1L;
-        Long memberId = 1L;
+
 
         when(memberRepository.findById(memberId)).thenReturn(java.util.Optional.of(member));
         when(socketRepository.findById(socketId)).thenReturn(java.util.Optional.of(socket));
@@ -85,8 +93,6 @@ public class BookmarkServiceTest {
 
     @Test
     public void 북마크실패_멤버없음() {
-        Long socketId = 1L;
-        Long memberId = 1L;
 
         when(memberRepository.findById(memberId)).thenReturn(java.util.Optional.empty());
 
@@ -100,8 +106,7 @@ public class BookmarkServiceTest {
 
     @Test
     public void 북마크실패_소켓없음() {
-        Long socketId = 1L;
-        Long memberId = 1L;
+
 
         when(memberRepository.findById(memberId)).thenReturn(java.util.Optional.of(member));
         when(socketRepository.findById(socketId)).thenReturn(java.util.Optional.empty());
@@ -116,8 +121,7 @@ public class BookmarkServiceTest {
 
     @Test
     public void 북마크실패_북마크없음() {
-        Long socketId = 1L;
-        Long memberId = 1L;
+
 
         when(memberRepository.findById(memberId)).thenReturn(java.util.Optional.of(member));
         when(socketRepository.findById(socketId)).thenReturn(java.util.Optional.of(socket));
@@ -129,4 +133,33 @@ public class BookmarkServiceTest {
 
         verify(bookmarkRepository, times(1)).save(any(Bookmark.class));
     }
+
+    @Test
+    public void 북마크리스트조회성공() {
+
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        Page<Bookmark> bookmarkPage = new PageImpl<>(Collections.singletonList(bookmark), PageRequest.of(page, 10), 1);
+        when(bookmarkRepository.findAllByMember(any(Member.class), any(PageRequest.class))).thenReturn(bookmarkPage);
+
+        Page<Bookmark> result = bookmarkService.findBookmarkList(memberId, page);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals(bookmark, result.getContent().get(0));
+    }
+
+    @Test
+    public void 북마크리스트조회실패_멤버없음() {
+
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        ErrorHandler thrown = assertThrows(ErrorHandler.class, () -> {
+            bookmarkService.findBookmarkList(memberId, page);
+        });
+
+        assertEquals(ErrorStatus.MEMBER_NOT_FOUND, thrown.getCode());
+    }
 }
+


### PR DESCRIPTION
## #️⃣연관된 이슈
> #21 

## 📝작업 내용
> 1. 소켓의 식별번호(이름) 추가
> 2. 북마크된 소켓의 정보 리스트 controller, service, repository, converter, dto 작성
> 3. 한 페이지 당 10개 리스트씩 보이도록 페이징 처리 
