### PR TITLE
Feat/25 피드백 생성하기 api

### DIFF
--- a/src/main/java/com/vincent/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/vincent/domain/feedback/controller/FeedbackController.java
@@ -1,12 +1,38 @@
 package com.vincent.domain.feedback.controller;
 
+import com.vincent.apipayload.ApiResponse;
+import com.vincent.domain.feedback.controller.dto.FeedbackRequestDto;
+import com.vincent.domain.feedback.service.FeedbackService;
+import com.vincent.domain.member.controller.dto.MemberRequestDto;
+import com.vincent.domain.member.controller.dto.MemberResponseDto;
+import com.vincent.domain.member.controller.dto.MemberResponseDto.Login;
+import com.vincent.domain.member.converter.MemberConverter;
+import com.vincent.domain.member.service.MemberService.LoginResult;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @Validated
+@RequestMapping("/v1")
 public class FeedbackController {
+
+  FeedbackService feedbackService;
+
+  @PostMapping("/feedback")
+  public ApiResponse<?> addFeedback(@RequestParam @Valid FeedbackRequestDto.addFeedbackDto request, Authentication authentication) {
+    Long memberId = Long.parseLong(authentication.getName());
+    feedbackService.addFeedback(request.getContents(), memberId);
+    return ApiResponse.onSuccess(null);
+  }
 
 }

--- a/src/main/java/com/vincent/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/vincent/domain/feedback/controller/FeedbackController.java
@@ -26,10 +26,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1")
 public class FeedbackController {
 
-  FeedbackService feedbackService;
+  private final FeedbackService feedbackService;
 
   @PostMapping("/feedback")
-  public ApiResponse<?> addFeedback(@RequestParam @Valid FeedbackRequestDto.addFeedbackDto request, Authentication authentication) {
+  public ApiResponse<?> addFeedback(@RequestBody @Valid FeedbackRequestDto.addFeedbackDto request, Authentication authentication) {
     Long memberId = Long.parseLong(authentication.getName());
     feedbackService.addFeedback(request.getContents(), memberId);
     return ApiResponse.onSuccess(null);

--- a/src/main/java/com/vincent/domain/feedback/controller/dto/FeedbackRequestDto.java
+++ b/src/main/java/com/vincent/domain/feedback/controller/dto/FeedbackRequestDto.java
@@ -1,5 +1,25 @@
 package com.vincent.domain.feedback.controller.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 public class FeedbackRequestDto {
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class addFeedbackDto {
+
+    @NotNull
+    @Size(max = 300)
+    String contents;
+  }
 
 }

--- a/src/main/java/com/vincent/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/vincent/domain/feedback/entity/Feedback.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Getter
@@ -35,5 +36,7 @@ public class Feedback {
     @Column(nullable = false, length = 300)
     private String content;
 
+    @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/vincent/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/vincent/domain/feedback/repository/FeedbackRepository.java
@@ -1,5 +1,9 @@
 package com.vincent.domain.feedback.repository;
 
-public class FeedbackRepository {
+import com.vincent.domain.feedback.entity.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
 
 }

--- a/src/main/java/com/vincent/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/vincent/domain/feedback/service/FeedbackService.java
@@ -1,10 +1,36 @@
 package com.vincent.domain.feedback.service;
 
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.feedback.entity.Feedback;
+import com.vincent.domain.feedback.repository.FeedbackRepository;
+import com.vincent.domain.member.entity.Member;
+import com.vincent.domain.member.repository.MemberRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class FeedbackService {
+
+  FeedbackRepository feedbackRepository;
+
+  MemberRepository memberRepository;
+
+  @Transactional
+  public void addFeedback(String contents, Long memberId) {
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+    Feedback feedback = Feedback.builder()
+        .content(contents)
+        .member(member)
+        .build();
+
+    feedbackRepository.save(feedback);
+  }
 
 }

--- a/src/test/java/com/vincent/domain/bookmark/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/FeedbackControllerTest.java
@@ -1,0 +1,104 @@
+package com.vincent.domain.bookmark.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.feedback.controller.FeedbackController;
+import com.vincent.domain.feedback.controller.dto.FeedbackRequestDto;
+import com.vincent.domain.feedback.service.FeedbackService;
+import com.vincent.exception.handler.ErrorHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(controllers = FeedbackController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class FeedbackControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private FeedbackService feedbackService;
+
+  Long memberId = 1L;
+
+  @Test
+  @WithMockUser(username = "1")
+  public void 피드백생성성공() throws Exception {
+
+    //requestDto 생성
+    FeedbackRequestDto.addFeedbackDto request = FeedbackRequestDto.addFeedbackDto.builder()
+        .contents("test contents")
+        .build();
+
+
+
+    ResultActions resultActions = mockMvc.perform(post("/v1/feedback")
+        .content(new ObjectMapper().writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+
+    resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.code").value("COMMON200"))
+        .andExpect(jsonPath("$.message").value("성공입니다"));
+
+    verify(feedbackService, times(1)).addFeedback(eq(request.getContents()), eq(memberId));
+
+
+
+  }
+
+  @Test
+  @WithMockUser(username = "1")
+  public void 피드백생성실패_멤버없음() throws Exception {
+
+    //requestDto 생성
+    FeedbackRequestDto.addFeedbackDto request = FeedbackRequestDto.addFeedbackDto.builder()
+        .contents("test contents")
+        .build();
+
+
+    // feedbackService.addFeedback 호출 시 예외를 던지도록 설정
+    doThrow(new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND)).when(feedbackService).addFeedback(eq(request.getContents()), eq(memberId));
+
+    ResultActions resultActions = mockMvc.perform(post("/v1/feedback")
+        .content(new ObjectMapper().writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+
+    resultActions.andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.MEMBER_NOT_FOUND.getReason().getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorStatus.MEMBER_NOT_FOUND.getReason().getMessage()));
+
+
+
+
+  }
+
+
+
+
+
+
+}

--- a/src/test/java/com/vincent/domain/bookmark/service/FeedbackServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/FeedbackServiceTest.java
@@ -1,0 +1,76 @@
+package com.vincent.domain.bookmark.service;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.feedback.entity.Feedback;
+import com.vincent.domain.feedback.repository.FeedbackRepository;
+import com.vincent.domain.feedback.service.FeedbackService;
+import com.vincent.domain.member.entity.Member;
+import com.vincent.domain.member.repository.MemberRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class FeedbackServiceTest {
+
+  @InjectMocks
+  private FeedbackService feedbackService;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private FeedbackRepository feedbackRepository;
+
+  @Mock
+  private Member member;
+
+  @Mock
+  private Feedback feedback;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+  }
+
+  Long memberId = 1L;
+  String contents = "test contents";
+
+  @Test
+  public void 피드백생성성공() {
+
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+    feedbackService.addFeedback(contents, memberId);
+
+    verify(feedbackRepository, times(1)).save(any(Feedback.class));
+  }
+
+  @Test
+  public void 피드백생성실패_멤버없음() {
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+    ErrorHandler thrown = assertThrows(ErrorHandler.class, () -> {
+      feedbackService.addFeedback(contents, memberId);
+    });
+
+    assertEquals(ErrorStatus.MEMBER_NOT_FOUND, thrown.getCode());
+    verify(feedbackRepository, never()).save(any(Feedback.class));
+  }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #25

## 📝작업 내용
> 주요 기능 : 프론트에서 contents를 dto로 받아  memberId와 contents를 Bookmark 엔티티로 변환하여 save한다
> 테스트 코드 : contents는 @Valid를 통해 max = 300을 검증했으므로, 성공하는 경우와 멤버가 존재하지 않는 경우만 테스트 함
