### PR TITLE
층 등록 API

### DIFF
--- a/src/main/java/com/vincent/config/aws/s3/S3Service.java
+++ b/src/main/java/com/vincent/config/aws/s3/S3Service.java
@@ -24,14 +24,17 @@ public class S3Service {
     public String bucket;  // S3 버킷
 
     public String BUILDING_IMG_DIR = "building";
+    public String FLOOR_IMG_DIR = "floor";
 
     // S3 파일 업로드
-    public String upload(MultipartFile multipartFile) throws IOException {
+    public String upload(MultipartFile multipartFile, String type) throws IOException {
         File convertFile = convert(multipartFile)
             .orElseThrow(
                 () -> new IllegalArgumentException("file convert error")); // 파일을 변환할 수 없으면 에러
 
-        String fileName = BUILDING_IMG_DIR + "/"  + UUID.randomUUID() + "_" + convertFile.getName();
+        String baseDir = type.equals("Floor") ? FLOOR_IMG_DIR : BUILDING_IMG_DIR;
+
+        String fileName = baseDir + "/" + UUID.randomUUID() + "_" + convertFile.getName();
 
         amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, convertFile));
 

--- a/src/main/java/com/vincent/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/vincent/domain/building/controller/BuildingController.java
@@ -54,4 +54,14 @@ public class BuildingController {
         return ApiResponse.onSuccess(null);
     }
 
+    @PostMapping("/building/{buildingId}/floors")
+    public ApiResponse<?> createFloor(
+        @PathVariable("buildingId") Long buildingId,
+        @RequestPart MultipartFile image,
+        @RequestPart int level)
+        throws IOException {
+        buildingService.createFloor(buildingId, level, image);
+        return ApiResponse.onSuccess(null);
+    }
+
 }

--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingRequestDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingRequestDto.java
@@ -2,15 +2,19 @@ package com.vincent.domain.building.controller.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 public class BuildingRequestDto {
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Create {
+
         private String name;
         private String address;
 
@@ -22,4 +26,5 @@ public class BuildingRequestDto {
         @Max(value = 90, message = "유효한 위도를 입력해 주세요.")
         private Double latitude;
     }
+
 }

--- a/src/main/java/com/vincent/domain/building/entity/Floor.java
+++ b/src/main/java/com/vincent/domain/building/entity/Floor.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,6 +28,9 @@ public class Floor {
     private Long id;
 
     private Integer level;
+
+    @Column(columnDefinition = "TEXT")
+    private String image;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "building_id", nullable = false)

--- a/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
@@ -1,0 +1,8 @@
+package com.vincent.domain.building.repository;
+
+import com.vincent.domain.building.entity.Floor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FloorRepository extends JpaRepository<Floor, Long> {
+
+}

--- a/src/main/java/com/vincent/domain/building/service/BuildingService.java
+++ b/src/main/java/com/vincent/domain/building/service/BuildingService.java
@@ -3,7 +3,9 @@ package com.vincent.domain.building.service;
 import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.config.aws.s3.S3Service;
 import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.repository.BuildingRepository;
+import com.vincent.domain.building.repository.FloorRepository;
 import com.vincent.exception.handler.ErrorHandler;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class BuildingService {
 
     private final BuildingRepository buildingRepository;
+    private final FloorRepository floorRepository;
     private final S3Service s3Service;
 
     public Building getBuildingInfo(Long buildingId) {
@@ -35,9 +38,24 @@ public class BuildingService {
 
     @Transactional
     public void createBuilding(Building building, MultipartFile image) throws IOException {
-        String uploadUrl = s3Service.upload(image);
+        String uploadUrl = s3Service.upload(image, "Building");
         building.setImage(uploadUrl);
         buildingRepository.save(building);
+    }
+
+    @Transactional
+    public void createFloor(Long buildingId, int level, MultipartFile image) throws IOException {
+        String uploadUrl = s3Service.upload(image, "Floor");
+        Building building = buildingRepository.findById(buildingId)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUILDING_NOT_FOUND));
+
+        Floor floor = Floor.builder()
+            .building(building)
+            .level(level)
+            .image(uploadUrl)
+            .build();
+
+        floorRepository.save(floor);
     }
 
 }

--- a/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
@@ -12,15 +12,19 @@ import static org.mockito.Mockito.when;
 import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.config.aws.s3.S3Service;
 import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.repository.BuildingRepository;
+import com.vincent.domain.building.repository.FloorRepository;
 import com.vincent.domain.building.service.BuildingService;
 import com.vincent.exception.handler.ErrorHandler;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -35,6 +39,9 @@ public class BuildingServiceTest {
 
     @Mock
     private BuildingRepository buildingRepository;
+
+    @Mock
+    private FloorRepository floorRepository;
 
     @Mock
     private S3Service s3Service;
@@ -99,7 +106,7 @@ public class BuildingServiceTest {
         Page<Building> buildingPage = new PageImpl<>(buildings, pageable, buildings.size());
 
         when(buildingRepository.findByNameContainingOrderBySimilarity(keyword,
-                PageRequest.of(page, 10))).thenReturn(buildingPage);
+            PageRequest.of(page, 10))).thenReturn(buildingPage);
 
         Page<Building> result = buildingService.getBuildingSearch(keyword, page);
 
@@ -117,13 +124,58 @@ public class BuildingServiceTest {
         String mockUrl = "test.com";
 
         //when
-        when(s3Service.upload(image)).thenReturn(mockUrl);
+        when(s3Service.upload(image, "Building")).thenReturn(mockUrl);
 
         //then
         buildingService.createBuilding(building, image);
-        verify(s3Service, times(1)).upload(eq(image));
+        verify(s3Service, times(1)).upload(eq(image), eq("Building"));
         verify(buildingRepository, times(1)).save(eq(building));
         assertEquals(mockUrl, building.getImage());
+    }
+
+    @Test
+    public void 층_등록_성공() throws IOException {
+        //given
+        MultipartFile image = mock(MultipartFile.class);
+        Long buildId = 1L;
+        Building building = Building.builder().build();
+        Floor floor = Floor.builder().build();
+        int level = 1;
+        String mockUrl = "test.com";
+
+        //when
+        when(s3Service.upload(image, "Floor")).thenReturn(mockUrl);
+        when(buildingRepository.findById(buildId)).thenReturn(Optional.of(building));
+
+        //then
+        buildingService.createFloor(buildId, level, image);
+        ArgumentCaptor<Floor> floorCaptor = ArgumentCaptor.forClass(Floor.class);
+        verify(floorRepository).save(floorCaptor.capture());
+
+        Floor savedFloor = floorCaptor.getValue();
+
+        assertEquals(mockUrl, savedFloor.getImage());
+        assertEquals(building, savedFloor.getBuilding());
+        assertEquals(level, savedFloor.getLevel());
+        verify(s3Service, times(1)).upload(eq(image), eq("Floor"));
+    }
+
+    @Test
+    public void 층_등록_실패() throws IOException {
+        //given
+        MultipartFile image = mock(MultipartFile.class);
+        Long buildId = 1L;
+        int level = 1;
+        String mockUrl = "test.com";
+
+        //when
+        when(s3Service.upload(image, "Floor")).thenReturn(mockUrl);
+        when(buildingRepository.findById(buildId)).thenReturn(Optional.empty());
+
+        ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class, () -> {
+            buildingService.createFloor(buildingId, level, image);
+        });
+        Assertions.assertEquals(ErrorStatus.BUILDING_NOT_FOUND, thrown.getCode());
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #44 

## 📝작업 내용
- 건물에 특정 층의 평면도를 등록
- 건물에 대한 예외 처리
- 테스트 코드 작성

controller에 대한 테스트 코드는 작성하지 못했습니다. 층을 등록할 때 공간 이미지도 함께 다 등록하게 하려고 했는데 dto로 여러개의 이미지를 받아오기가 힘들어서 우선 층에 대해서만 처리했습니다.
