### PR TITLE
Feat/42 주변 건물 조회 api

### DIFF
--- a/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
@@ -88,10 +88,7 @@ public class BookmarkService {
 
 
     public void delete(Member member, Socket socket) {
-        bookmarkRepository.delete(Bookmark.builder()
-            .member(member)
-            .socket(socket)
-            .build());
+        bookmarkRepository.delete(Bookmark.builder().member(member).socket(socket).build());
     }
 
 
@@ -100,13 +97,11 @@ public class BookmarkService {
     }
 
     private Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-            .orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        return memberRepository.findById(memberId).orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
     private Socket findSocketById(Long socketId) {
-        return socketRepository.findById(socketId)
-            .orElseThrow(() -> new ErrorHandler(ErrorStatus.SOCKET_NOT_FOUND));
+        return socketRepository.findById(socketId).orElseThrow(() -> new ErrorHandler(ErrorStatus.SOCKET_NOT_FOUND));
     }
 
 

--- a/src/main/java/com/vincent/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/vincent/domain/building/controller/BuildingController.java
@@ -5,6 +5,7 @@ import com.vincent.domain.building.controller.dto.BuildingResponseDto;
 import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.service.BuildingService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
@@ -35,6 +36,15 @@ public class BuildingController {
         @RequestParam("page") Integer page) {
         Page<Building> buildingPage = buildingService.getBuildingSearch(keyword, page);
         return ApiResponse.onSuccess(BuildingConverter.toBuildingListResponse(buildingPage));
+    }
+
+    @GetMapping("/building/location")
+    public ApiResponse<BuildingResponseDto.BuildingLocationList> buildingLocation(
+        @RequestParam("longitude") Double longitude,
+        @RequestParam("latitude") Double latitude) {
+        List<Building> buildingList = buildingService.getBuildingLocation(longitude, latitude);
+        return ApiResponse.onSuccess(
+            BuildingConverter.toBuildingLocationListResponse(buildingList));
     }
 
 }

--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
@@ -42,8 +42,8 @@ public class BuildingResponseDto {
     public static class BuildingLocation {
 
         Long buildingId;
-        Double xCoordinate;
-        Double yCoordinate;
+        Double latitude;
+        Double longitude;
 
     }
 

--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
@@ -35,4 +35,26 @@ public class BuildingResponseDto {
 
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BuildingLocation {
+
+        Long buildingId;
+        Double xCoordinate;
+        Double yCoordinate;
+
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BuildingLocationList {
+
+        List<BuildingLocation> buildingLocations;
+
+    }
+
 }

--- a/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
+++ b/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
@@ -51,8 +51,8 @@ public class BuildingConverter {
         Building result) {
         return BuildingResponseDto.BuildingLocation.builder()
             .buildingId(result.getId())
-            .xCoordinate(result.getLongitude())
-            .yCoordinate(result.getLatitude())
+            .latitude(result.getLatitude())
+            .longitude(result.getLongitude())
             .build();
     }
 

--- a/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
+++ b/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
@@ -25,7 +25,7 @@ public class BuildingConverter {
         Page<Building> result) {
 
         List<BuildingResponseDto.BuildingInfo> buildingInfoList = result.stream()
-                .map(BuildingConverter::toBuildingInfoResponse).collect(Collectors.toList());
+            .map(BuildingConverter::toBuildingInfoResponse).collect(Collectors.toList());
 
         return BuildingResponseDto.BuildingList.builder()
             .isFirst(result.isFirst())
@@ -36,5 +36,24 @@ public class BuildingConverter {
             .buildingInfos(buildingInfoList)
             .build();
     }
+
+    public static BuildingResponseDto.BuildingLocation toBuildingLocationResponse(
+        Building result) {
+        return BuildingResponseDto.BuildingLocation.builder()
+            .buildingId(result.getId())
+            .xCoordinate(result.getXCoordinate())
+            .yCoordinate(result.getYCoordinate())
+            .build();
+    }
+
+    public static BuildingResponseDto.BuildingLocationList toBuildingLocationListResponse(
+        List<Building> result) {
+        List<BuildingResponseDto.BuildingLocation> b = result.stream()
+            .map(BuildingConverter::toBuildingLocationResponse).collect(Collectors.toList());
+        return BuildingResponseDto.BuildingLocationList.builder()
+            .buildingLocations(b)
+            .build();
+    }
+
 
 }

--- a/src/main/java/com/vincent/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/BuildingRepository.java
@@ -10,17 +10,26 @@ import org.springframework.data.repository.query.Param;
 
 public interface BuildingRepository extends JpaRepository<Building, Long> {
 
-    @SuppressWarnings("checkstyle:OperatorWrap")
-    @Query(value = "SELECT * FROM Building b WHERE b.name LIKE CONCAT('%', :keyword, '%') " +
-            "ORDER BY CASE " +
-            "WHEN b.name = :keyword THEN 0 " +
-            "WHEN b.name LIKE CONCAT(:keyword, '%') THEN 1 " +
-            "WHEN b.name LIKE CONCAT('%', :keyword, '%') THEN 2 " +
-            "WHEN b.name LIKE CONCAT('%', :keyword) THEN 3 " +
-            "ELSE 4 END",
-            countQuery = "SELECT count(*) FROM Building b WHERE b.name LIKE CONCAT('%', :keyword, '%')",
-            nativeQuery = true)
-    Page<Building> findByNameContainingOrderBySimilarity(@Param("keyword") String keyword,
-            PageRequest pageRequest);
+    @Query(
+        value = "SELECT * FROM Building b WHERE b.name LIKE CONCAT('%', :keyword, '%') "
+            + "ORDER BY CASE "
+            + "WHEN b.name = :keyword THEN 0 "
+            + "WHEN b.name LIKE CONCAT(:keyword, '%') THEN 1 "
+            + "WHEN b.name LIKE CONCAT('%', :keyword, '%') THEN 2 "
+            + "WHEN b.name LIKE CONCAT('%', :keyword) THEN 3 "
+            + "ELSE 4 END",
+        countQuery = "SELECT count(*) FROM Building b WHERE b.name LIKE CONCAT('%', :keyword, '%')",
+        nativeQuery = true
+    )
+    Page<Building> findByNameContainingOrderBySimilarity(@Param("keyword") String keyword, PageRequest pageRequest);
+
+
+    @Query(
+        value = "SELECT * FROM Building b "
+            + "WHERE (b.x_coordinate > :x-0.001 AND b.x_coordinate < :x+0.001) "
+            + "AND (b.y_coordinate > :y-0.003 AND b.y_coordinate < :y+0.003)",
+        nativeQuery = true
+    )
+    List<Building> findAllByLocation(@Param("x") Double x, @Param("y") Double y);
 
 }

--- a/src/main/java/com/vincent/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/BuildingRepository.java
@@ -25,11 +25,16 @@ public interface BuildingRepository extends JpaRepository<Building, Long> {
 
 
     @Query(
-        value = "SELECT * FROM Building b "
-            + "WHERE (b.x_coordinate > :x-0.001 AND b.x_coordinate < :x+0.001) "
-            + "AND (b.y_coordinate > :y-0.003 AND b.y_coordinate < :y+0.003)",
+        value = "SELECT * FROM Building "
+            + "WHERE longitude BETWEEN :longitudeLower AND :longitudeUpper "
+            + "AND latitude BETWEEN :latitudeLower AND :latitudeUpper",
         nativeQuery = true
     )
-    List<Building> findAllByLocation(@Param("x") Double x, @Param("y") Double y);
+    List<Building> findAllByLocation(
+        @Param("longitudeLower") Double longitudeLower,
+        @Param("longitudeUpper") Double longitudeUpper,
+        @Param("latitudeLower") Double latitudeLower,
+        @Param("latitudeUpper") Double latitudeUpper
+    );
 
 }

--- a/src/main/java/com/vincent/domain/building/service/BuildingService.java
+++ b/src/main/java/com/vincent/domain/building/service/BuildingService.java
@@ -42,7 +42,13 @@ public class BuildingService {
     }
 
     public List<Building> getBuildingLocation(Double longitude, Double latitude) {
-        return buildingRepository.findAllByLocation(longitude, latitude);
+        double longitudeRange = 3.1; //임의의 범위
+        double latitudeRange = 6.1; //임의의 범위
+        double longitudeLower = longitude - longitudeRange;
+        double longitudeUpper = longitude + longitudeRange;
+        double latitudeLower = latitude - latitudeRange;
+        double latitudeUpper = latitude + latitudeRange;
+        return buildingRepository.findAllByLocation(longitudeLower, longitudeUpper, latitudeLower, latitudeUpper);
 
     }
 

--- a/src/main/java/com/vincent/domain/building/service/BuildingService.java
+++ b/src/main/java/com/vincent/domain/building/service/BuildingService.java
@@ -1,9 +1,12 @@
 package com.vincent.domain.building.service;
 
 import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto;
+import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.repository.BuildingRepository;
 import com.vincent.exception.handler.ErrorHandler;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,7 +29,12 @@ public class BuildingService {
     public Page<Building> getBuildingSearch(String keyword, Integer page) {
 
         return buildingRepository.findByNameContainingOrderBySimilarity(keyword,
-                PageRequest.of(page, 10));
+            PageRequest.of(page, 10));
+    }
+
+    public List<Building> getBuildingLocation(Double longitude, Double latitude) {
+        return buildingRepository.findAllByLocation(longitude, latitude);
+
     }
 
 

--- a/src/test/java/com/vincent/domain/bookmark/controller/BuildingControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/BuildingControllerTest.java
@@ -14,12 +14,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vincent.apipayload.ApiResponse;
 import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.domain.building.controller.BuildingController;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto;
 import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.service.BuildingService;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.exception.handler.ErrorHandler;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -127,5 +129,40 @@ public class BuildingControllerTest {
                         ApiResponse.onSuccess(
                                 BuildingConverter.toBuildingListResponse(buildingPage))
                 )));
+    }
+
+    @Test
+    @WithMockUser
+    public void 주변건물조회_성공() throws Exception {
+
+        BuildingResponseDto.BuildingLocation location = BuildingResponseDto.BuildingLocation.builder()
+            .buildingId(1L)
+            .longitude(36.1)
+            .latitude(120.1)
+            .build();
+
+        BuildingResponseDto.BuildingLocationList locationList = BuildingResponseDto.BuildingLocationList.builder()
+            .buildingLocations(Collections.singletonList(location))
+            .build();
+
+        given(buildingService.getBuildingLocation(36.0, 120.0)).willReturn(Collections.singletonList(
+            Building.builder()
+                .id(1L)
+                .longitude(36.1)
+                .latitude(120.1)
+                .build()
+        ));
+
+        ResultActions resultActions = mockMvc.perform(get("/v1/building/location")
+                .param("longitude", "36.0")
+                .param("latitude", "120.0")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+
+            resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.buildingLocations[0].buildingId").value(1))
+            .andExpect(jsonPath("$.result.buildingLocations[0].longitude").value(36.1))
+            .andExpect(jsonPath("$.result.buildingLocations[0].latitude").value(120.1));
     }
 }

--- a/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
@@ -17,6 +17,7 @@ import com.vincent.domain.building.service.BuildingService;
 import com.vincent.exception.handler.ErrorHandler;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +31,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuildingServiceTest {
 
@@ -124,6 +126,26 @@ public class BuildingServiceTest {
         verify(s3Service, times(1)).upload(eq(image));
         verify(buildingRepository, times(1)).save(eq(building));
         assertEquals(mockUrl, building.getImage());
+    }
+
+    @Test
+    public void 주변건물조회_성공() {
+
+        Building building = Building.builder()
+            .id(1L)
+            .longitude(36.1)
+            .latitude(120.1)
+            .build();
+
+        given(buildingRepository.findAllByLocation(32.900, 39.100, 113.900, 126.100))
+            .willReturn(Collections.singletonList(building));
+
+        List<Building> result = buildingService.getBuildingLocation(36.0, 120.0);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(0).getLongitude()).isEqualTo(36.1);
+        assertThat(result.get(0).getLatitude()).isEqualTo(120.1);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #42 

## 📝작업 내용
> 컨트롤러 : 지도 상의 중간 값을 파라미터로 받음
> 서비스 : 지도 상의 중간 값의 위도, 경도의 최소, 최대값을 계산한 뒤 해당 파라미터들을 레포지토리로 전달
> 레포지토리 : 위도, 경도의 최소, 최대 범위 안에 longitude와 latitude가 있으면 해당 빌딩들을 리스트 형태로 전달
> Dto : 주변 빌딩의 전체 리스트, 각 빌딩의 정보 dto 작성
> 컨버터 : 빌딩 전체 리스트를 빌딩의 id, 위도, 경도 값들만의 리스트로 변환
> 컨트롤러, 서비스 테스트 코드

> 문제점 : swagger에서 성공이라고 떠도 리스트가 안 보임
(db에 직접 repository의 findAllByLocation쿼리를 날려도 데이터가 안 떠요.. 해결해보다가 시간이 좀 걸려버렸습니다..)
{
  "isSuccess": true,
  "code": "string",
  "message": "string",
  "result": {
    "buildingLocations": [
      {
        "buildingId": 0,
        "latitude": 0,
        "longitude": 0
      }
    ]
  }
}