### PR TITLE
Feat/38 개별 콘센트 조회 api

### DIFF
--- a/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/vincent/domain/bookmark/controller/BookmarkController.java
@@ -58,6 +58,8 @@ public class BookmarkController {
         return ApiResponse.onSuccess(BookmarkConverter.toBookmarkListResponse(bookmarkList));
     }
 
+
+    /*
     @GetMapping("/bookmark/{socketId}")
     public ApiResponse<BookmarkResponseDto.BookmarkExistence> getBookmarkExist(
         @PathVariable("socketId") Long socketId,
@@ -68,6 +70,8 @@ public class BookmarkController {
         Boolean result = bookmarkService.getBookmarkExist(socketId, memberId);
         return ApiResponse.onSuccess(BookmarkConverter.toBookmarkExistenceResponse(result));
     }
+
+     */
 
 
 }

--- a/src/main/java/com/vincent/domain/socket/controller/SocketController.java
+++ b/src/main/java/com/vincent/domain/socket/controller/SocketController.java
@@ -1,13 +1,41 @@
 package com.vincent.domain.socket.controller;
 
 
+import com.vincent.apipayload.ApiResponse;
+import com.vincent.config.security.principal.PrincipalDetails;
+import com.vincent.domain.bookmark.service.BookmarkService;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto;
+import com.vincent.domain.socket.converter.SocketConverter;
+import com.vincent.domain.socket.entity.Socket;
+import com.vincent.domain.socket.service.SocketService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @Validated
+@RequestMapping("/v1")
 public class SocketController {
+
+    private final SocketService socketService;
+    private final BookmarkService bookmarkService;
+
+    @GetMapping("/socket/{socketId}")
+    public ApiResponse<SocketResponseDto.SocketInfo> socketInfo(@PathVariable("socketId") Long socketId,
+        Authentication authentication) {
+
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        Long memberId = principalDetails.getMemberId();
+        Boolean isBookmarkExist = bookmarkService.getBookmarkExist(socketId, memberId);
+        Socket socketInfo = socketService.getSocketInfo(socketId);
+        return ApiResponse.onSuccess(SocketConverter.toSocketInfoResponse(socketInfo, isBookmarkExist));
+    }
+
+
 
 }

--- a/src/main/java/com/vincent/domain/socket/controller/dto/SocketResponseDto.java
+++ b/src/main/java/com/vincent/domain/socket/controller/dto/SocketResponseDto.java
@@ -1,5 +1,25 @@
 package com.vincent.domain.socket.controller.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class SocketResponseDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SocketInfo {
+
+        Long socketId;
+        String socketName;
+        String socketImage;
+        String buildingName;
+        String spaceName;
+        Boolean isBookmarkExist;
+
+    }
 
 }

--- a/src/main/java/com/vincent/domain/socket/converter/SocketConverter.java
+++ b/src/main/java/com/vincent/domain/socket/converter/SocketConverter.java
@@ -1,5 +1,19 @@
 package com.vincent.domain.socket.converter;
 
+import com.vincent.domain.socket.controller.dto.SocketResponseDto;
+import com.vincent.domain.socket.entity.Socket;
+
 public class SocketConverter {
+
+    public static SocketResponseDto.SocketInfo toSocketInfoResponse(Socket socketInfo, Boolean isBookmarkExist) {
+        return SocketResponseDto.SocketInfo.builder()
+            .socketId(socketInfo.getId())
+            .socketName(socketInfo.getName())
+            .socketImage(socketInfo.getImage())
+            .buildingName(socketInfo.getSpace().getFloor().getBuilding().getName())
+            .spaceName(socketInfo.getSpace().getName())
+            .isBookmarkExist(isBookmarkExist)
+            .build();
+    }
 
 }

--- a/src/main/java/com/vincent/domain/socket/service/SocketService.java
+++ b/src/main/java/com/vincent/domain/socket/service/SocketService.java
@@ -1,10 +1,23 @@
 package com.vincent.domain.socket.service;
 
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.socket.entity.Socket;
+import com.vincent.domain.socket.repository.SocketRepository;
+import com.vincent.exception.handler.ErrorHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SocketService {
+
+    private final SocketRepository socketRepository;
+
+    public Socket getSocketInfo(Long socketId) {
+
+        return  socketRepository.findById(socketId).orElseThrow(() -> new ErrorHandler(ErrorStatus.SOCKET_NOT_FOUND));
+    }
 
 }

--- a/src/test/java/com/vincent/domain/bookmark/controller/SocketControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/SocketControllerTest.java
@@ -1,0 +1,107 @@
+package com.vincent.domain.bookmark.controller;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vincent.domain.bookmark.service.BookmarkService;
+import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.socket.controller.SocketController;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketInfo;
+import com.vincent.domain.socket.converter.SocketConverter;
+import com.vincent.domain.socket.entity.Socket;
+import com.vincent.domain.socket.service.SocketService;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(controllers = SocketController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class SocketControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SocketService socketService;
+
+    @MockBean
+    private BookmarkService bookmarkService;
+
+    @MockBean
+    private SocketConverter socketConverter;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    Long socketId = 1L;
+    Long memberId = 1L;
+
+    @Test
+    @WithMockUser
+    public void 개별_콘센트_조회_성공() throws Exception {
+
+        Boolean isBookmarkExist = true;
+
+        Building building = Mockito.mock(Building.class);
+        when(building.getName()).thenReturn("s1_building1");
+
+        Floor floor = Mockito.mock(Floor.class);
+        when(floor.getBuilding()).thenReturn(building);
+
+        Space space = Mockito.mock(Space.class);
+        when(space.getFloor()).thenReturn(floor);
+        when(space.getName()).thenReturn("s1_floor1");
+
+        Socket socket = Mockito.mock(Socket.class);
+        when(socket.getId()).thenReturn(socketId);
+        when(socket.getName()).thenReturn("s1");
+        when(socket.getImage()).thenReturn("s1_image");
+        when(socket.getSpace()).thenReturn(space);
+
+        SocketResponseDto.SocketInfo socketInfo = new SocketInfo(
+            socketId, "s1", "s1_image", "s1_building", " s1_floor1", true);
+
+        when(bookmarkService.getBookmarkExist(eq(socketId), eq(memberId))).thenReturn(isBookmarkExist);
+        when(socketService.getSocketInfo(eq(socketId))).thenReturn(socket);
+
+        try (MockedStatic<SocketConverter> mockedConverter = Mockito.mockStatic(SocketConverter.class)) {
+            mockedConverter.when(() -> SocketConverter.toSocketInfoResponse(socket, isBookmarkExist))
+                .thenReturn(socketInfo);
+
+            ResultActions resultActions = mockMvc.perform(get("/v1/socket/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+            resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("성공입니다"))
+                .andExpect(jsonPath("$.result.socketId").value(socketId))
+                .andExpect(jsonPath("$.result.socketName").value("s1"))
+                .andExpect(jsonPath("$.result.socketImage").value("s1_image"))
+                .andExpect(jsonPath("$.result.buildingName").value("s1_building1"))
+                .andExpect(jsonPath("$.result.spaceName").value("s1_floor1"))
+                .andExpect(jsonPath("$.result.isBookmarkExist").value(isBookmarkExist));
+
+
+        }
+
+    }
+}

--- a/src/test/java/com/vincent/domain/bookmark/service/SocketServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/SocketServiceTest.java
@@ -1,0 +1,72 @@
+package com.vincent.domain.bookmark.service;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.socket.entity.Socket;
+import com.vincent.domain.socket.repository.SocketRepository;
+import com.vincent.domain.socket.service.SocketService;
+import com.vincent.exception.handler.ErrorHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+import org.mockito.Spy;
+
+public class SocketServiceTest {
+
+    @Mock
+    private SocketRepository socketRepository;
+
+    @InjectMocks
+    private SocketService socketService;
+
+    @Spy
+    private Socket socket;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void 개별_콘센트_조회_성공() {
+
+        Long socketId = 1L;
+
+        when(socket.getId()).thenReturn(socketId);
+
+
+        when(socketRepository.findById(socketId)).thenReturn(Optional.of(socket));
+
+
+
+        Socket result = socketService.getSocketInfo(socketId);
+
+
+        assertNotNull(result);
+        assertEquals(socketId, result.getId());
+        verify(socketRepository, times(1)).findById(socketId);
+    }
+
+    @Test
+    public void 개별_콘센트_조회_실패_소켓없음() {
+        Long socketId = 1L;
+
+        when(socketRepository.findById(socketId)).thenReturn(Optional.empty());
+
+        ErrorHandler thrown = assertThrows(ErrorHandler.class, () -> {
+            socketService.getSocketInfo(socketId);
+        });
+
+        assertEquals(ErrorStatus.SOCKET_NOT_FOUND, thrown.getCode());
+        verify(socketRepository, times(1)).findById(socketId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #38 

## 📝작업 내용
 1. socketId와 memberId를 각각 socketService와 bookmarkService에 전달하여 소켓정보, 북마크 여부를 받아와 SocketConverter에 전달해서, 소켓정보와 북마크 정보를 합친 ResponseDto를 프론트에 전달하도록 함
 2. 기존의 북마크 여부 조회 api(BookmarkController에 있던 api)는 주석처리함
 3. 개별 콘센트 조회 컨트롤러 테스트의 예외 상황은 테스트 하지 못함. 나머지 컨트롤러 성공 테스트, 서비스의 성공/예외 테스트는 정상적으로 실행됨

