### PR TITLE
Feat/50 층 조회 api

### DIFF
--- a/src/main/java/com/vincent/apipayload/status/ErrorStatus.java
+++ b/src/main/java/com/vincent/apipayload/status/ErrorStatus.java
@@ -44,7 +44,7 @@ public enum ErrorStatus implements BaseCode {
     // 층
     FLOOR_NOT_FOUND(HttpStatus.NOT_FOUND, "FLOOR4001", "층 정보를 찾을 수 없습니다."),
 
-    //이밎
+    //이미지
     IMAGE_CONVERT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE4001", "이미지 변환 중 에러가 발생했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/vincent/apipayload/status/ErrorStatus.java
+++ b/src/main/java/com/vincent/apipayload/status/ErrorStatus.java
@@ -39,7 +39,10 @@ public enum ErrorStatus implements BaseCode {
     SOCKET_NOT_FOUND(HttpStatus.NOT_FOUND, "SOCKET4001", "소켓 정보를 찾을 수 없습니다."),
 
     // 빌딩
-    BUILDING_NOT_FOUND(HttpStatus.NOT_FOUND, "BUILDING4001", "빌딩 정보를 찾을 수 없습니다.");
+    BUILDING_NOT_FOUND(HttpStatus.NOT_FOUND, "BUILDING4001", "빌딩 정보를 찾을 수 없습니다."),
+
+    // 층
+    FLOOR_NOT_FOUND(HttpStatus.NOT_FOUND, "FLOOR4001", "층 정보를 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/vincent/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/vincent/domain/building/controller/BuildingController.java
@@ -95,11 +95,12 @@ public class BuildingController {
     public ApiResponse<?> createSpace(
         @PathVariable("floorId") Long floorId,
         @RequestPart("image") MultipartFile image,
-        @RequestPart("xCoordinate") int xCoordinate,
-        @RequestPart("yCoordinate") int yCoordinate,
-        @RequestPart("name") String name)
+        @RequestParam("name") String name,
+        @RequestParam("xCoordinate") double xCoordinate,
+        @RequestParam("yCoordinate") double yCoordinate,
+        @RequestParam("isSocketExist") boolean isSocketExist)
         throws IOException {
-        buildingService.createSpace(floorId, image, xCoordinate, yCoordinate, name);
+        buildingService.createSpace(floorId, image, xCoordinate, yCoordinate, name, isSocketExist);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/com/vincent/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/vincent/domain/building/controller/BuildingController.java
@@ -5,6 +5,8 @@ import com.vincent.domain.building.controller.dto.BuildingRequestDto;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto;
 import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.building.service.BuildingService;
 import jakarta.validation.Valid;
 import java.io.IOException;
@@ -73,5 +75,20 @@ public class BuildingController {
         return ApiResponse.onSuccess(
             BuildingConverter.toBuildingLocationListResponse(buildingList));
     }
+
+    @GetMapping("/building/floor")
+    public ApiResponse<BuildingResponseDto.FloorInfoList> floorInfoList(
+        @RequestParam("buildingId") Long buildingId,
+        @RequestParam("level") Integer level) {
+        Floor floor = buildingService.getFloorInfo(buildingId, level);
+        List<Floor> floors = buildingService.getFloorInfoList(buildingId);
+        List<Space> spaces = buildingService.getSpaceInfoList(floor.getId());
+
+        return  ApiResponse.onSuccess((
+            BuildingConverter.toFloorInfoListResponse(floor, floors, spaces)));
+
+
+    }
+
 
 }

--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
@@ -57,4 +57,30 @@ public class BuildingResponseDto {
 
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FloorInfoList {
+
+        String buildingName;
+        Integer floors;
+        Integer currentFloor;
+        List<SpaceInfo> spaceInfoList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SpaceInfo {
+
+        String spaceName;
+        Double xCoordinate;
+        Double yCoordinate;
+        Boolean socketExistence;
+    }
+
+
+
 }

--- a/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
+++ b/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
@@ -7,6 +7,8 @@ import com.vincent.domain.building.controller.dto.BuildingRequestDto;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.BuildingInfo;
 import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
@@ -64,6 +66,31 @@ public class BuildingConverter {
             .buildingLocations(b)
             .build();
     }
+
+    public static BuildingResponseDto.SpaceInfo toSpaceInfoResponse(
+        Space space) {
+        return BuildingResponseDto.SpaceInfo.builder()
+            .spaceName(space.getName())
+            .xCoordinate(space.getXCoordinate())
+            .yCoordinate(space.getYCoordinate())
+            .socketExistence(space.isSocketExist()).build();
+
+    }
+
+    public static BuildingResponseDto.FloorInfoList toFloorInfoListResponse(
+        Floor floor, List<Floor> floors, List<Space> spaces) {
+
+        List<BuildingResponseDto.SpaceInfo> spaceInfoList = spaces.stream()
+            .map(BuildingConverter::toSpaceInfoResponse).collect(Collectors.toList());
+
+        return  BuildingResponseDto.FloorInfoList.builder()
+            .buildingName(floor.getBuilding().getName())
+            .floors(floors.size())
+            .currentFloor(floor.getLevel())
+            .spaceInfoList(spaceInfoList)
+            .build();
+    }
+
 
 
 }

--- a/src/main/java/com/vincent/domain/building/entity/Space.java
+++ b/src/main/java/com/vincent/domain/building/entity/Space.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,5 +36,8 @@ public class Space {
     private double yCoordinate;
 
     private String name;
+
+    @ColumnDefault("false")
+    private boolean isSocketExist;
 
 }

--- a/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
@@ -1,8 +1,18 @@
 package com.vincent.domain.building.repository;
 
+import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface FloorRepository extends JpaRepository<Floor, Long> {
+
+
+    Floor findByBuildingAndLevel(Building building, Integer level);
+
+    List<Floor> findAllByBuilding(Building building);
 
 }

--- a/src/main/java/com/vincent/domain/building/repository/SpaceRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/SpaceRepository.java
@@ -1,0 +1,14 @@
+package com.vincent.domain.building.repository;
+
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpaceRepository extends JpaRepository<Space, Long> {
+
+
+
+    List<Space> findAllByFloor(Floor floor);
+
+}

--- a/src/main/java/com/vincent/domain/building/service/BuildingService.java
+++ b/src/main/java/com/vincent/domain/building/service/BuildingService.java
@@ -4,8 +4,11 @@ import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.config.aws.s3.S3Service;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.building.repository.BuildingRepository;
 import com.vincent.domain.building.repository.FloorRepository;
+import com.vincent.domain.building.repository.SpaceRepository;
+import com.vincent.domain.member.entity.Member;
 import com.vincent.exception.handler.ErrorHandler;
 import java.io.IOException;
 import java.util.List;
@@ -23,6 +26,7 @@ public class BuildingService {
 
     private final BuildingRepository buildingRepository;
     private final FloorRepository floorRepository;
+    private final SpaceRepository spaceRepository;
     private final S3Service s3Service;
 
     public Building getBuildingInfo(Long buildingId) {
@@ -68,6 +72,39 @@ public class BuildingService {
         double latitudeUpper = latitude + latitudeRange;
         return buildingRepository.findAllByLocation(longitudeLower, longitudeUpper, latitudeLower, latitudeUpper);
 
+    }
+
+    public Floor getFloorInfo(Long buildingId, Integer level) {
+
+        Building building = findBuildingById(buildingId);
+
+        return floorRepository.findByBuildingAndLevel(building, level);
+
+    }
+
+    public List<Floor> getFloorInfoList(Long buildingId) {
+
+        Building building = findBuildingById(buildingId);
+
+        return floorRepository.findAllByBuilding(building);
+
+    }
+
+    public List<Space> getSpaceInfoList(Long floorId) {
+
+        Floor floor = findFloorById(floorId);
+
+        return spaceRepository.findAllByFloor(floor);
+
+    }
+
+    private Building findBuildingById(Long buildingId) {
+        return buildingRepository.findById(buildingId)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUILDING_NOT_FOUND));
+    }
+
+    private Floor findFloorById(Long floorId) {
+        return floorRepository.findById(floorId).orElseThrow(() -> new ErrorHandler(ErrorStatus.FLOOR_NOT_FOUND));
     }
 
 

--- a/src/main/java/com/vincent/domain/building/service/BuildingService.java
+++ b/src/main/java/com/vincent/domain/building/service/BuildingService.java
@@ -108,7 +108,8 @@ public class BuildingService {
     }
 
     @Transactional
-    public void createSpace(Long floorId, MultipartFile image, int x, int y, String name) throws IOException {
+    public void createSpace(
+        Long floorId, MultipartFile image, double x, double y, String name, boolean isSocketExist) throws IOException {
         String uploadUrl = s3Service.upload(image, "Space");
         Floor floor = floorRepository.findById(floorId)
             .orElseThrow(() -> new ErrorHandler(ErrorStatus.FLOOR_NOT_FOUND));
@@ -119,6 +120,7 @@ public class BuildingService {
             .xCoordinate(x)
             .yCoordinate(y)
             .image(uploadUrl)
+            .isSocketExist(isSocketExist)
             .build();
 
         spaceRepository.save(space);

--- a/src/test/java/com/vincent/domain/bookmark/controller/BuildingControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/BuildingControllerTest.java
@@ -235,8 +235,9 @@ public class BuildingControllerTest {
         Long floorId = 1L;
         MockMultipartFile image = new MockMultipartFile("image", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "test image".getBytes());
         String name = "Test Space";
-        int xCoordinate = 10;
-        int yCoordinate = 20;
+        double xCoordinate = 10;
+        double yCoordinate = 20;
+        boolean isSocketExist = true;
 
 
         mockMvc.perform(multipart("/v1/building/floors/{floorId}/spaces", floorId)
@@ -248,7 +249,7 @@ public class BuildingControllerTest {
             .with(SecurityMockMvcRequestPostProcessors.csrf()))
             .andExpect(status().isOk());
 
-        verify(buildingService).createSpace(floorId, image, xCoordinate, yCoordinate, name);
+        verify(buildingService).createSpace(floorId, image, xCoordinate, yCoordinate, name, isSocketExist);
     }
 
 

--- a/src/test/java/com/vincent/domain/bookmark/controller/BuildingControllerTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/controller/BuildingControllerTest.java
@@ -17,9 +17,12 @@ import com.vincent.domain.building.controller.BuildingController;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto;
 import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.building.service.BuildingService;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.exception.handler.ErrorHandler;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -64,14 +67,14 @@ public class BuildingControllerTest {
         given(buildingService.getBuildingInfo(eq(buildingId))).willReturn(building);
 
         ResultActions resultActions = mockMvc.perform(get("/v1/building/{buildingId}", buildingId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(SecurityMockMvcRequestPostProcessors.csrf()));
 
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true))
-                .andExpect(jsonPath("$.code").value("COMMON200"))
-                .andExpect(jsonPath("$.message").value("성공입니다"))
-                .andExpect(jsonPath("$.result").exists());
+            .andExpect(jsonPath("$.isSuccess").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"))
+            .andExpect(jsonPath("$.message").value("성공입니다"))
+            .andExpect(jsonPath("$.result").exists());
         ;
     }
 
@@ -79,18 +82,18 @@ public class BuildingControllerTest {
     @WithMockUser
     public void 건물정보조회실패_건물없음() throws Exception {
         given(buildingService.getBuildingInfo(eq(buildingId)))
-                .willThrow(new ErrorHandler(ErrorStatus.BUILDING_NOT_FOUND));
+            .willThrow(new ErrorHandler(ErrorStatus.BUILDING_NOT_FOUND));
 
         ResultActions resultActions = mockMvc.perform(get("/v1/building/{buildingId}", buildingId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(SecurityMockMvcRequestPostProcessors.csrf()));
 
         resultActions.andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.isSuccess").value(false))
-                .andExpect(jsonPath("$.code").value(
-                        ErrorStatus.BUILDING_NOT_FOUND.getReason().getCode()))
-                .andExpect(jsonPath("$.message").value(
-                        ErrorStatus.BUILDING_NOT_FOUND.getReason().getMessage()));
+            .andExpect(jsonPath("$.isSuccess").value(false))
+            .andExpect(jsonPath("$.code").value(
+                ErrorStatus.BUILDING_NOT_FOUND.getReason().getCode()))
+            .andExpect(jsonPath("$.message").value(
+                ErrorStatus.BUILDING_NOT_FOUND.getReason().getMessage()));
     }
 
     @Test
@@ -118,17 +121,17 @@ public class BuildingControllerTest {
         when(buildingService.getBuildingSearch(keyword, page)).thenReturn(buildingPage);
 
         ResultActions resultActions = mockMvc.perform(get("/v1/building/search")
-                .param("keyword", keyword)
-                .param("page", String.valueOf(page))
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+            .param("keyword", keyword)
+            .param("page", String.valueOf(page))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(SecurityMockMvcRequestPostProcessors.csrf()));
 
         resultActions.andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().json(objectMapper.writeValueAsString(
-                        ApiResponse.onSuccess(
-                                BuildingConverter.toBuildingListResponse(buildingPage))
-                )));
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(objectMapper.writeValueAsString(
+                ApiResponse.onSuccess(
+                    BuildingConverter.toBuildingListResponse(buildingPage))
+            )));
     }
 
     @Test
@@ -154,15 +157,67 @@ public class BuildingControllerTest {
         ));
 
         ResultActions resultActions = mockMvc.perform(get("/v1/building/location")
-                .param("longitude", "36.0")
-                .param("latitude", "120.0")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+            .param("longitude", "36.0")
+            .param("latitude", "120.0")
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(SecurityMockMvcRequestPostProcessors.csrf()));
 
-
-            resultActions.andExpect(status().isOk())
+        resultActions.andExpect(status().isOk())
             .andExpect(jsonPath("$.result.buildingLocations[0].buildingId").value(1))
             .andExpect(jsonPath("$.result.buildingLocations[0].longitude").value(36.1))
             .andExpect(jsonPath("$.result.buildingLocations[0].latitude").value(120.1));
+    }
+
+
+    @Test
+    @WithMockUser
+    public void 층_조회_성공() throws Exception {
+        Long buildingId = 1L;
+        Integer level = 2;
+
+        Building building = Mockito.mock(Building.class);
+
+        Floor floor = Mockito.mock(Floor.class);
+        when(floor.getLevel()).thenReturn(level);
+        when(floor.getBuilding()).thenReturn(building);
+
+        List<Floor> floors = new ArrayList<>();
+        List<Space> spaces = new ArrayList<>();
+
+        when(buildingService.getFloorInfo(buildingId, level)).thenReturn(floor);
+        when(buildingService.getFloorInfoList(buildingId)).thenReturn(floors);
+        when(buildingService.getSpaceInfoList(floor.getId())).thenReturn(spaces);
+
+        BuildingResponseDto.FloorInfoList floorInfoList = BuildingResponseDto.FloorInfoList.builder()
+            .buildingName("Building 1")
+            .floors(3)
+            .currentFloor(2)
+            .spaceInfoList(new ArrayList<>())
+            .build();
+
+        when(BuildingConverter.toFloorInfoListResponse(floor, floors, spaces)).thenReturn(floorInfoList);
+
+        mockMvc.perform(get("/v1/building/floor")
+                .param("buildingId", buildingId.toString())
+                .param("level", level.toString())
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.buildingName").value("Building 1"));
+    }
+
+    @Test
+    @WithMockUser
+    public void 층_조회_실패_빌딩없음() throws Exception {
+        Long buildingId = 1L;
+        Integer level = 2;
+
+        when(buildingService.getFloorInfo(buildingId, level)).thenThrow(
+            new ErrorHandler(ErrorStatus.BUILDING_NOT_FOUND));
+
+        mockMvc.perform(get("/v1/building/floor")
+                .param("buildingId", buildingId.toString())
+                .param("level", level.toString())
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+            .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
@@ -263,10 +263,11 @@ public class BuildingServiceTest {
 
         Long floorId = 1L;
         MultipartFile image = null;
-        int xCoordinate = 10;
-        int yCoordinate = 20;
+        double xCoordinate = 10;
+        double yCoordinate = 20;
         String name = "Test Space";
         String uploadUrl = "https://s3.amazonaws.com/example.jpg";
+        boolean isSocketExist = true;
 
         Building building = Building.builder()
             .id(1L)
@@ -284,7 +285,7 @@ public class BuildingServiceTest {
         when(floorRepository.findById(floorId)).thenReturn(Optional.of(floor));
         when(s3Service.upload(any(MultipartFile.class), any(String.class))).thenReturn(uploadUrl);
 
-        buildingService.createSpace(floorId, image, xCoordinate, yCoordinate, name);
+        buildingService.createSpace(floorId, image, xCoordinate, yCoordinate, name, isSocketExist);
 
         verify(spaceRepository).save(any(Space.class));
         verify(s3Service).upload(any(MultipartFile.class), any(String.class));
@@ -295,12 +296,13 @@ public class BuildingServiceTest {
 
         Long floorId = 1L;
         MultipartFile image = null;
+        boolean isSocketExist = true;
 
         when(floorRepository.findById(floorId)).thenReturn(Optional.empty());
 
 
         assertThrows(ErrorHandler.class, () -> {
-            buildingService.createSpace(floorId, image, 10, 20, "Test Space");
+            buildingService.createSpace(floorId, image, 10, 20, "Test Space", isSocketExist);
         });
     }
 

--- a/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/BuildingServiceTest.java
@@ -1,6 +1,7 @@
 package com.vincent.domain.bookmark.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -18,6 +19,7 @@ import com.vincent.domain.building.repository.FloorRepository;
 import com.vincent.domain.building.service.BuildingService;
 import com.vincent.exception.handler.ErrorHandler;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,6 +37,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuildingServiceTest {
@@ -199,5 +202,54 @@ public class BuildingServiceTest {
         assertThat(result.get(0).getLongitude()).isEqualTo(36.1);
         assertThat(result.get(0).getLatitude()).isEqualTo(120.1);
     }
+
+    @Test
+    public void 층_조회_getFloorInfo_성공() {
+        Long buildingId = 1L;
+        Integer level = 2;
+        Building building = Mockito.mock(Building.class);
+
+        Floor floor = Mockito.mock(Floor.class);
+        when(floor.getLevel()).thenReturn(level);
+        when(floor.getBuilding()).thenReturn(building);
+
+        when(buildingRepository.findById(buildingId)).thenReturn(Optional.of(building));
+        when(floorRepository.findByBuildingAndLevel(building, level)).thenReturn(floor);
+
+        Floor result = buildingService.getFloorInfo(buildingId, level);
+
+        assertNotNull(result);
+        assertEquals(level, result.getLevel());
+    }
+
+
+    @Test
+    public void 층_조회_getFloorInfo_실패_Floor없음() {
+        Long buildingId = 1L;
+        Integer level = 2;
+        Building building = Mockito.mock(Building.class);
+
+        when(buildingRepository.findById(buildingId)).thenReturn(Optional.of(building));
+        when(floorRepository.findByBuildingAndLevel(building, level)).thenReturn(null);
+
+        buildingService.getFloorInfo(buildingId, level);
+    }
+
+    @Test
+    public void 층_조회_getFloorInfoList_성공() {
+        Long buildingId = 1L;
+        Building building = Mockito.mock(Building.class);
+
+        List<Floor> floors = new ArrayList<>();
+
+        when(buildingRepository.findById(buildingId)).thenReturn(Optional.of(building));
+        when(floorRepository.findAllByBuilding(building)).thenReturn(floors);
+
+        List<Floor> result = buildingService.getFloorInfoList(buildingId);
+
+        assertNotNull(result);
+        assertEquals(floors, result);
+    }
+
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #50 

## 📝작업 내용

## 1. api 생성
건물 Id와 층을 RequestParam으로 받아서 해당 건물의 이름, 총 층 수, 현재 층, 공간의 정보 리스트들이 조회되도록 했습니다.

## 2. Floor 엔티티 수정
Floor엔티티에 isSocketExist 필드를 추가했습니다
해당 필드를 추가하지않고 소켓 존재 여부를 BuildingSerivce에서 조회할 수 있지만, 그렇게 되면
BuilidingConverter의 toSpaceInfoResponse메서드의 파라미터가 space 엔티티와 Boolean형의 isSocketExist가 되고,
그러면 BuilidingConverter의 toFloorInfoListResponse메서드에서 map함수를 쓰지 못하게 됩니다.
따라서 Floor엔티티에 isSocketExist 필드를 추가했는데 다른 의견 주시면 바꾸겠습니다

## 3. 테스트 코드
controller테스트 코드는 완성했지만 service테스트 코드는 모두 작성하지못했습니다. 나머지 api를 만들고 추가하겠습니다
