### PR TITLE
[Bug/76] Hikaripool Thread starvation 오류

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASS}
+    hikari:
+      maximum-pool-size: 50
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## #️⃣연관된 이슈
> #76 

## 📝작업 내용
1. 서버가 터졌을 때 아래와 같은 오류가 나서 우선 pool-size를 50으로 늘려줬습니다. 아마 서버에 누가 악의적으로 계속 트래픽을 보내서 과부하가 걸리게 했던거 같은데 제가 따로 Nginx 설정을 안해둬서 정확한 원인은 파악하지 못했습니다.
2. 로깅을 위해 서버에 Nginx 설치

> springboot    | [2024-08-24 22:06:39:225711454]  WARN  1 --- [l-1 housekeeper] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Thread starvation or clock leap detected (housekeeper delta=2m3s344ms900µs621ns).