### PR TITLE
[Refactor/80] Service 코드 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 src/main/resources/application.yml
+monitoring/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
@@ -48,9 +48,7 @@ public class BookmarkService {
         Socket socket = findSocketById(socketId);
 
         if (!isBookmarkExists(socket, member)) {
-            {
-                throw new ErrorHandler(ErrorStatus.BOOKMARK_ALREADY_DELETED);
-            }
+            throw new ErrorHandler(ErrorStatus.BOOKMARK_ALREADY_DELETED);
         }
 
         delete(member, socket);

--- a/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
@@ -1,0 +1,40 @@
+package com.vincent.domain.bookmark.service.data;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.bookmark.entity.Bookmark;
+import com.vincent.domain.bookmark.repository.BookmarkRepository;
+import com.vincent.domain.member.entity.Member;
+import com.vincent.domain.socket.entity.Socket;
+import com.vincent.exception.handler.ErrorHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkDataService {
+
+    private final BookmarkRepository bookmarkRepository;
+
+    public void delete(Bookmark bookmark) {
+        bookmarkRepository.delete(bookmark);
+    }
+
+    public Bookmark save(Bookmark bookmark) {
+        return bookmarkRepository.save(bookmark);
+    }
+
+    public void isBookmarkExists(Socket socket, Member member) {
+        Boolean exists = bookmarkRepository.existsBySocketAndMember(socket, member);
+        if (exists) {
+            throw new ErrorHandler(ErrorStatus.BOOKMARK_ALREADY_EXIST);
+        }
+    }
+
+    public Page<Bookmark> findAllByMember(Member member, Integer page) {
+        return bookmarkRepository.findAllByMemberOrderByCreatedAtDesc(member,
+            PageRequest.of(page, 10));
+    }
+
+}

--- a/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
@@ -24,19 +24,12 @@ public interface FloorRepository extends JpaRepository<Floor, Long> {
         + "FROM Building b "
         + "JOIN Floor f "
         + "ON b.id = f.building.id "
-        + "WHERE b.id = :buildingId AND f.level = :level")  // spaceInfoList를 제외
+        + "WHERE b.id = :buildingId AND f.level = :level")
+        // spaceInfoList를 제외
     FloorInfoProjection findFloorInfoByBuildingIdAndLevel(
         @Param("buildingId") Long buildingId,
-        @Param("level") int level);
-
-
-
-
-
-
-
-
-
+        @Param("level") int level
+    );
 
 
 }

--- a/src/main/java/com/vincent/domain/building/service/data/BuildingDataService.java
+++ b/src/main/java/com/vincent/domain/building/service/data/BuildingDataService.java
@@ -1,0 +1,45 @@
+package com.vincent.domain.building.service.data;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.repository.BuildingRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BuildingDataService {
+
+    private final BuildingRepository buildingRepository;
+
+    public Building findById(Long id) {
+        return buildingRepository.findById(id)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUILDING_NOT_FOUND));
+    }
+
+    public Building save(Building building) {
+        return buildingRepository.save(building);
+    }
+
+    public List<Building> findAllByLocation(Double longitude, Double latitude) {
+        final double longitudeRange = 0.0007092929741;
+        final double latitudeRange = 0.00146597950179;
+
+        double longitudeLower = longitude - longitudeRange;
+        double longitudeUpper = longitude + longitudeRange;
+        double latitudeLower = latitude - latitudeRange;
+        double latitudeUpper = latitude + latitudeRange;
+
+        return buildingRepository.findAllByLocation(longitudeLower, longitudeUpper, latitudeLower, latitudeUpper);
+    }
+
+    public Page<Building> findAllByName(String keyword, Integer page) {
+        return buildingRepository.findByNameContainingOrderBySimilarity(keyword,
+            PageRequest.of(page, 10));
+    }
+
+}

--- a/src/main/java/com/vincent/domain/building/service/data/FloorDataService.java
+++ b/src/main/java/com/vincent/domain/building/service/data/FloorDataService.java
@@ -1,0 +1,21 @@
+package com.vincent.domain.building.service.data;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.repository.FloorRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FloorDataService {
+
+    private final FloorRepository floorRepository;
+
+    public Floor findById(Long id) {
+        return floorRepository.findById(id)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.FLOOR_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/vincent/domain/building/service/data/SpaceDataService.java
+++ b/src/main/java/com/vincent/domain/building/service/data/SpaceDataService.java
@@ -1,0 +1,27 @@
+package com.vincent.domain.building.service.data;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.building.repository.SpaceRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SpaceDataService {
+
+    private final SpaceRepository spaceRepository;
+
+    public Space save(Space space) {
+        return spaceRepository.save(space);
+    }
+
+    public Space findById(Long id) {
+        return spaceRepository.findById(id)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.SPACE_NOT_FOUND));
+    }
+
+
+
+}

--- a/src/main/java/com/vincent/domain/feedback/service/data/FeedbackDataService.java
+++ b/src/main/java/com/vincent/domain/feedback/service/data/FeedbackDataService.java
@@ -1,0 +1,16 @@
+package com.vincent.domain.feedback.service.data;
+
+import com.vincent.domain.feedback.entity.Feedback;
+import com.vincent.domain.feedback.repository.FeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackDataService {
+    private final FeedbackRepository feedbackRepository;
+
+    public Feedback save (Feedback feedback) {
+        return feedbackRepository.save(feedback);
+    }
+}

--- a/src/main/java/com/vincent/domain/member/service/data/MemberDataService.java
+++ b/src/main/java/com/vincent/domain/member/service/data/MemberDataService.java
@@ -1,0 +1,30 @@
+package com.vincent.domain.member.service.data;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.member.entity.Member;
+import com.vincent.domain.member.repository.MemberRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDataService {
+
+    private final MemberRepository memberRepository;
+
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public void save(Member member) {
+        memberRepository.save(member);
+    }
+
+}

--- a/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
+++ b/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
@@ -1,0 +1,31 @@
+package com.vincent.domain.socket.service.data;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.socket.entity.Socket;
+import com.vincent.domain.socket.repository.SocketRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SocketDataService {
+
+    private final SocketRepository socketRepository;
+
+    public Socket findById(Long id) {
+        return socketRepository.findById(id)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.SOCKET_NOT_FOUND));
+    }
+
+    public List<Socket> findAllBySpace(Space space) {
+        return socketRepository.findAllBySpace(space);
+    }
+
+    public Socket save(Socket socket) {
+        return socketRepository.save(socket);
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #80 

## 📝작업 내용
1. Data 계층 생성
> 기존 방식이 controller -> service -> repository 였는데 service 계층에서 repository에 접근해서 데이터 검증 및 비지니스 로직을 모두 처리헤고 되면서 코드의 복잡도가 증가해서 이러한 문제를 해결하기 위해 가운데 data 계층을 새로 생성함

> 변경된 방식은 controler -> serivce -> data -> repository  순서로 service 계층에서는 비지니스 로직에만 집중하고, data 계층에서 repository에 접근해서 데이터를 가져오고 검증하는 역할을 수행하도록 했다. 

일단 최대한 data 계층에 넣을 수 있는 건 다 넣어봤는데 몇 개 빼먹은 건 있을 수 있습니다...😅😅