### PR TITLE
[Refactor/83] MemberService 코드 수정

### DIFF
--- a/src/main/java/com/vincent/config/redis/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/vincent/config/redis/repository/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/vincent/config/redis/service/RedisService.java
+++ b/src/main/java/com/vincent/config/redis/service/RedisService.java
@@ -1,9 +1,11 @@
 package com.vincent.config.redis.service;
 
+import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.config.redis.repository.RefreshTokenRepository;
 import com.vincent.config.security.provider.JwtProvider;
 import com.vincent.domain.member.entity.Member;
 import com.vincent.config.redis.entity.RefreshToken;
+import com.vincent.exception.handler.ErrorHandler;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -22,33 +24,31 @@ public class RedisService {
      * 리프레시 토큰 발급
      */
     public RefreshToken generateRefreshToken(Member member) {
-        String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
-        return refreshTokenRepository.save(
-                RefreshToken.builder()
-                        .memberId(member.getId())
-                        .refreshToken(refreshToken)
-                        .build()
-        );
+        String token = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
+        RefreshToken refreshToken = RefreshToken.builder().memberId(member.getId())
+            .refreshToken(token).build();
+        return refreshTokenRepository.save(refreshToken);
     }
 
     /**
      * 리프레시 토큰 찾기
      */
-    public Optional<RefreshToken> findRefreshToken(Long memberId) {
-        return refreshTokenRepository.findById(memberId);
+    public RefreshToken findByMemberId(Long id) {
+        return refreshTokenRepository.findById(id)
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.JWT_REFRESH_TOKEN_EXPIRED));
     }
 
     /**
      * 리프레시 토큰 재발급
      */
-    public RefreshToken reGenerateRefreshToken(Member member, RefreshToken refreshToken) {
+    public RefreshToken regenerateRefreshToken(Member member, RefreshToken refreshToken) {
         refreshTokenRepository.delete(refreshToken);
         String newRefreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
         return refreshTokenRepository.save(
-                RefreshToken.builder()
-                        .memberId(member.getId())
-                        .refreshToken(newRefreshToken)
-                        .build()
+            RefreshToken.builder()
+                .memberId(member.getId())
+                .refreshToken(newRefreshToken)
+                .build()
         );
     }
 
@@ -59,13 +59,17 @@ public class RedisService {
         refreshTokenRepository.delete(refreshToken);
     }
 
+    public void delete(Long memberId) {
+        refreshTokenRepository.deleteByMemberId(memberId);
+    }
+
     /**
      * 액세스 토큰 블랙리스트 등록
      */
     public void blacklist(String accessToken) {
         Long expireAccessMs = jwtProvider.getExpireAccessMs(accessToken);
         redisTemplate.opsForValue()
-                .set(accessToken, "logout", expireAccessMs, TimeUnit.MILLISECONDS);
+            .set(accessToken, "logout", expireAccessMs, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -73,6 +77,24 @@ public class RedisService {
      */
     public boolean isBlacklisted(String accessToken) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(accessToken));
+    }
+
+    /**
+     * 리프레시 토큰 존재 여부 반환
+     */
+
+    public boolean exists(Long memberId) {
+        return refreshTokenRepository.existsById(memberId);
+    }
+
+    /**
+     * 탈취 검증
+     */
+    public void verifyTokenNotHijacked(RefreshToken refreshToken, String providedToken) {
+        if (!refreshToken.getRefreshToken().equals(providedToken)) {
+            this.delete(refreshToken);
+            throw new ErrorHandler(ErrorStatus.ANOTHER_USER);
+        }
     }
 
 }

--- a/src/main/java/com/vincent/domain/member/service/data/MemberDataService.java
+++ b/src/main/java/com/vincent/domain/member/service/data/MemberDataService.java
@@ -23,8 +23,8 @@ public class MemberDataService {
             .orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
-    public void save(Member member) {
-        memberRepository.save(member);
+    public Member save(Member member) {
+        return memberRepository.save(member);
     }
 
 }

--- a/src/test/java/com/vincent/config/redis/service/RedisServiceTest.java
+++ b/src/test/java/com/vincent/config/redis/service/RedisServiceTest.java
@@ -1,0 +1,230 @@
+package com.vincent.config.redis.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.config.redis.entity.RefreshToken;
+import com.vincent.config.redis.repository.RefreshTokenRepository;
+import com.vincent.config.security.provider.JwtProvider;
+import com.vincent.domain.member.entity.Member;
+import com.vincent.exception.handler.ErrorHandler;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisServiceTest {
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @InjectMocks
+    private RedisService redisService;
+
+
+    @Test
+    void 리프레시토큰생성() {
+        //given
+        String token = "test";
+
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken("test")
+            .build();
+        Member member = Member.builder()
+            .id(1L)
+            .email("test@gmail.com")
+            .build();
+        //when
+        when(jwtProvider.createRefreshToken(member.getId(), member.getEmail())).thenReturn(token);
+        when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(refreshToken);
+        RefreshToken result = redisService.generateRefreshToken(member);
+
+        //then
+        Assertions.assertEquals(result, refreshToken);
+    }
+
+    @Test
+    void 사용자Id로토큰찾기() {
+        //when
+        Long memberId = 1L;
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken("test")
+            .build();
+
+        //given
+        when(refreshTokenRepository.findById(memberId)).thenReturn(Optional.of(refreshToken));
+        RefreshToken result = redisService.findByMemberId(memberId);
+
+        //then
+        Assertions.assertEquals(result, refreshToken);
+    }
+
+    @Test
+    void 사용자Id로토큰찾기_실패() {
+        //given
+        Long memberId = 1L;
+
+        //when
+        when(refreshTokenRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        //then
+        ErrorHandler thrown = assertThrows(ErrorHandler.class,
+            () -> redisService.findByMemberId(memberId));
+        Assertions.assertEquals(thrown.getCode(), ErrorStatus.JWT_REFRESH_TOKEN_EXPIRED);
+    }
+
+    @Test
+    void 토큰재발급() {
+        //given
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken("test")
+            .build();
+        RefreshToken newRefreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken("test2")
+            .build();
+        Member member = Member.builder()
+            .id(1L)
+            .email("test@gmail.com")
+            .build();
+
+        //when
+        doNothing().when(refreshTokenRepository).delete(refreshToken);
+        when(jwtProvider.createRefreshToken(member.getId(), member.getEmail())).thenReturn("test2");
+        when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(newRefreshToken);
+        RefreshToken result = redisService.regenerateRefreshToken(member, refreshToken);
+
+        //then
+        Assertions.assertEquals(result.getMemberId(), newRefreshToken.getMemberId());
+        Assertions.assertEquals(result.getRefreshToken(), newRefreshToken.getRefreshToken());
+    }
+
+    @Test
+    void 리프레시토큰으로삭제() {
+        //given
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken("test")
+            .build();
+
+        //when
+        doNothing().when(refreshTokenRepository).delete(refreshToken);
+        redisService.delete(refreshToken);
+
+        //then
+        verify(refreshTokenRepository, times(1)).delete(refreshToken);
+    }
+
+    @Test
+    void 사용자Id로삭제() {
+        //given
+        Long memberId = 1L;
+
+        //when
+        doNothing().when(refreshTokenRepository).deleteByMemberId(memberId);
+        redisService.delete(memberId);
+
+        //then
+        verify(refreshTokenRepository, times(1)).deleteByMemberId(memberId);
+    }
+
+    @Test
+    void 액세스토큰블랙리스트에등록() {
+        // given
+        String accessToken = "test";
+        Long expireAccessMs = 60000L;
+        ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
+
+        // when
+        when(jwtProvider.getExpireAccessMs(accessToken)).thenReturn(expireAccessMs);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        redisService.blacklist(accessToken);
+
+        // then
+        verify(valueOperations, times(1)).set(eq(accessToken), eq("logout"), eq(expireAccessMs), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void 액세스토큰블랙리스트검증() {
+        //given
+        String accessToken = "test";
+
+        //when
+        when(redisTemplate.hasKey(accessToken)).thenReturn(true);
+        boolean blacklisted = redisService.isBlacklisted(accessToken);
+
+        //then
+        Assertions.assertEquals(blacklisted, true);
+        verify(redisTemplate, times(1)).hasKey(accessToken);
+
+    }
+
+    @Test
+    void 사용자Id로토큰존재확인() {
+        // given
+        Long memberId = 1L;
+        when(refreshTokenRepository.existsById(memberId)).thenReturn(true);
+
+        // when
+        boolean result = redisService.exists(memberId);
+
+        // then
+        assertTrue(result);
+        verify(refreshTokenRepository, times(1)).existsById(memberId);
+    }
+
+    @Test
+    void 탈취검증_위험없음() {
+        //given
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken("test")
+            .build();
+        String providedToken = "test";
+
+        //when/then
+        assertDoesNotThrow(() -> redisService.verifyTokenNotHijacked(refreshToken, providedToken));
+    }
+
+    @Test
+    void 탈취검증_위험있음() {
+        //given
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken("test")
+            .build();
+        String providedToken = "test2";
+
+        //when
+        ErrorHandler thrown = assertThrows(ErrorHandler.class,
+            () -> redisService.verifyTokenNotHijacked(refreshToken, providedToken));
+
+        //then
+        Assertions.assertEquals(thrown.getCode(), ErrorStatus.ANOTHER_USER);
+    }
+
+}

--- a/src/test/java/com/vincent/domain/member/service/data/MemberDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/member/service/data/MemberDataServiceTest.java
@@ -1,0 +1,93 @@
+package com.vincent.domain.member.service.data;
+
+
+import static org.mockito.Mockito.when;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.member.entity.Member;
+import com.vincent.domain.member.repository.MemberRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberDataServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberDataService memberDataService;
+
+    @Test
+    void 이메일로사용자찾기() {
+        //given
+        String email = "test@gmail.com";
+
+        Member member = Member.builder()
+            .id(1L)
+            .email("test@gmail.com")
+            .build();
+
+        //when
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+
+        //then
+        Optional<Member> result = memberDataService.findByEmail(email);
+        Assertions.assertEquals(result.get(), member);
+    }
+
+    @Test
+    void 아이디로사용자찾기() {
+        //given
+        Long id = 1L;
+
+        Member member = Member.builder()
+            .id(1L)
+            .email("test@gmail.com")
+            .build();
+
+        //when
+        when(memberRepository.findById(id)).thenReturn(Optional.of(member));
+
+        //then
+        Member result = memberDataService.findById(id);
+        Assertions.assertEquals(result, member);
+    }
+
+    @Test
+    void 아이디로사용자찾기_실패() {
+        //given
+        Long id = 1L;
+
+        //when
+        when(memberRepository.findById(id)).thenReturn(Optional.empty());
+
+        //then
+        ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
+            () -> memberDataService.findById(id));
+
+        Assertions.assertEquals(thrown.getCode(), ErrorStatus.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    void 사용자저장() {
+        //given
+        Member member = Member.builder()
+            .id(1L)
+            .email("test@gmail.com")
+            .build();
+
+        //when
+        when(memberRepository.save(member)).thenReturn(member);
+
+        //then
+        Member result = memberDataService.save(member);
+        Assertions.assertEquals(result, member);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #83 

## 📝작업 내용
1. MeberService에서 MemberRepository에 직접 접근해서 데이터를 가져오지 않고 MemberDataService를 통해서 데이터에 접근할 수 있도록 수정.
2. MemberService에서 순수하게 비지니스 로직에만 집중할 수 있게, 예외 처리를 모드 MemberDataService, RedisService에서 할 수 있게 수정.
3. 수정된 코드에 맞게 테스트 코드 재작성 (MemberService, MeberDataService, RedisService)

### 이점
- 기존의 MemberService가 비즈니스 로직과 데이터 접근 로직을 모두 포함하고 있었기 때문에, 테스트 코드 작성 시 여러 가지 의존성을 관리해야 했지만 이제 MemberService와 MemberDataService로 역할이 명확하게 분리됨에 따라, 각각의 단위 테스트를 더 쉽게 작성할 수 있게 됐다.
-  MemberService와 MemberDataService가 각각 명확한 책임을 가지게 되면서, 코드가 더 이해하기 쉽고 유지보수하기 쉬워졌다.
